### PR TITLE
Little clean up so relay port specification is centralized

### DIFF
--- a/Android/src/main/java/com/msopentech/ThaliClient/ProxyExtensionClient.java
+++ b/Android/src/main/java/com/msopentech/ThaliClient/ProxyExtensionClient.java
@@ -31,12 +31,17 @@ public class ProxyExtensionClient extends XWalkExtensionClient {
     public static final String HttpKeysNotification = "com.msopentech.thali.devicehub.android.httpkeys";
     public static final String LocalMachineIPHttpKeyURLName = "LocalMachineIPHttpKeyURL";
     public static final String OnionHttpKeyURLName = "OnionHttpKeyURLName";
+    public static final String SocksOnionProxyPort = "SocksOnionProxyPort";
     public static final String TDHClassName = "com.msopentech.thali.devicehub.android.ThaliDeviceHubService";
     // I had to use native Android logging rather than SLF4J logging because right now there isn't a good way to
     // include AARs in our crosswalk build. When we flip to using the CrossWalk webview then this problem will
     // hopefully go away and we can use SLF4J again.
     // https://github.com/thaliproject/ThaliHTML5ApplicationFramework/issues/18
     public static final String LogTag = "com.msopentech.thali.ThaliClient.android";
+    // Host and port for the relay
+    // These go away with https://github.com/thaliproject/ThaliHTML5ApplicationFramework/issues/4
+    public static final String relayHost = "127.0.0.1";
+    public static final int relayPort = 58000;
 
     private volatile ContentResolver resolver;
     private volatile Context context;
@@ -50,7 +55,8 @@ public class ProxyExtensionClient extends XWalkExtensionClient {
             final HttpKeyTypes httpKeyTypes =
                     new HttpKeyTypes(
                             new HttpKeyURL(bundle.getString(LocalMachineIPHttpKeyURLName)),
-                            new HttpKeyURL(bundle.getString(OnionHttpKeyURLName)));
+                            new HttpKeyURL(bundle.getString(OnionHttpKeyURLName)),
+                            Integer.parseInt(bundle.getString(SocksOnionProxyPort)));
             // I explicitly didn't use an AsyncTask for this because the Android docs say that an AsyncTask
             // should only take a few seconds at most and starting a network port can take awhile.
             new Thread(new Runnable() {
@@ -90,7 +96,7 @@ public class ProxyExtensionClient extends XWalkExtensionClient {
         try {
             server = new RelayWebServer(
                     new AndroidEktorpCreateClientBuilder(),
-                    context.getDir("keystore", Context.MODE_PRIVATE), httpKeyTypes);
+                    context.getDir("keystore", Context.MODE_PRIVATE), httpKeyTypes, relayHost, relayPort);
         } catch (Exception e) {
             Log.e(LogTag,"Could not created RelayWebServer!", e);
             return;

--- a/Java/src/main/java/com/msopentech/ThaliClient/ProxyDesktop.java
+++ b/Java/src/main/java/com/msopentech/ThaliClient/ProxyDesktop.java
@@ -36,6 +36,10 @@ import java.util.Properties;
 // per http://docs.oracle.com/javase/tutorial/uiswing/misc/systemtray.html
 
 public class ProxyDesktop  {
+    // Host and port for the relay
+    // These go away with https://github.com/thaliproject/ThaliHTML5ApplicationFramework/issues/4
+    public static final String relayHost = "127.0.0.1";
+    public static final int relayPort = 58000;
     private static final int localWebserverPort = 58001;
 
     public RelayWebServer server;
@@ -115,7 +119,8 @@ public class ProxyDesktop  {
         HttpKeyTypes httpKeyTypes = mapper.readValue(httpKeysFile, HttpKeyTypes.class);
 
         try {
-            server = new RelayWebServer(new JavaEktorpCreateClientBuilder(), webDirectory, httpKeyTypes);
+            server = new RelayWebServer(new JavaEktorpCreateClientBuilder(), webDirectory, httpKeyTypes, relayHost,
+                    relayPort);
         } catch (Exception e) {
             throw new RuntimeException("cannot start relay web server!", e);
         }
@@ -129,7 +134,7 @@ public class ProxyDesktop  {
             System.out.println("Starting WebServer at http://localhost:" + localWebserverPort);
             host.start();
 
-            System.out.println("Starting Relay on http://" + RelayWebServer.relayHost + ":" + RelayWebServer.relayPort);
+            System.out.println("Starting Relay on http://" + relayHost + ":" + relayPort);
             server.start();
         } catch(IOException ioe) {
             System.out.println("Exception: " + ioe.toString());

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -4,8 +4,8 @@
         <script src="bower_components/pouchdb/dist/pouchdb-nightly.js"></script>
         <script src="bower_components/jquery/dist/jquery.min.js"></script>
         <script src="bower_components/JavaScript-MD5/js/md5.js"></script>
-        <script src="js/pouchdb_sync.js"></script>
         <script src="js/tdh_replication.js"></script>
+        <script src="js/pouchdb_sync.js"></script>
         <script src="js/tdh_replication_test.js"></script>
     </head>
 

--- a/web/src/js/pouchdb_sync.js
+++ b/web/src/js/pouchdb_sync.js
@@ -20,71 +20,6 @@ exports = exports.PouchDBSync;
 // enable extra debug logging?
 var enableDebugLogging = true;
 
-// what is the relay address?
-var relayAddress = "http://localhost:58000";
-
-/**
- * This is a very fragile temporary function to let the address book grab a httpKey and shove it into
- * the key database.
- * @param httpKey
- */
-var addHttpKeyToPermissionDatabase = function(httpKey) {
-    var rsakeytype = "rsapublickey";
-    var keyDatabaseName = "thaliprincipaldatabase";
-    /*
-     new PouchDB(request.from);
-     Take HTTPKEYURL from foreign point, parse it to get out the public key parts and then put those into the
-
-     keydatabase
-
-     The document in keybase has four fields
-     id - Exactly the value out of the httpkeyurl
-     keyType - "RSAKeyType"
-     modulus -
-     exponent -
-
-     Parsing HTTPKEYURL - httpkey://domain/publickey/stuff
-     So do a split on "/" and we know the public key starts at 3 (check in JS obviously)
-     The publickey will be of the form: "rsapublickey:" + Exponent + "." + modulus
-     Then do a starts with rsapublickey: check and then substring to remove it
-     Then split on "." and you are good to go!
-
-     Will return a JSON object of the form
-     { id: x,
-     requestBody: y }
-
-     Using Pouch we want to avoid a conflict so we will first do a get to get the current revision
-     So easiest is just to do a get, grab the rev if any and then use it on the put.
-
-     */
-    var rsaPublicKeyString = httpKey.split("/")[3];
-    // We don't do a -1 on rsakeytype.length because we want to eat the ":" separator
-    var rsaPublicKeySplit = rsaPublicKeyString.substr(rsakeytype.length).split(".");
-    var publicKeyDoc = {};
-    publicKeyDoc.keyType = rsakeytype;
-    publicKeyDoc.exponent = rsaPublicKeySplit[0];
-    publicKeyDoc.modulus = rsaPublicKeySplit[1];
-    // Yes, we use the same string as the record ID
-    var recordId = rsaPublicKeyString;
-
-    var keyDatabasePouch = new PouchDB(relayAddress + "/" + keyDatabaseName);
-    keyDatabasePouch.get(recordId).then(
-        function(doc) {
-            return Promise.resolve();
-        },
-        function(err) {
-            keyDatabasePouch.put(publicKeyDoc, recordId).then(
-                function(response) {
-                    return Promise.resolve();
-                }, function(err) {
-                    return Promise.reject(err);
-                }
-            );
-        });
-};
-
-exports.addHttpKeyToPermissionDatabase = addHttpKeyToPermissionDatabase;
-
 /**
  * Replication request:
  *  from - src of replication
@@ -160,17 +95,6 @@ function enableLogging(doit) {
     enableDebugLogging = doit;
 }
 exports.enableLogging = enableLogging;
-
-    /**
-     * Set location of relay.
-     * @param address
-     */
-function setRelayAddress(address) {
-    if(relayAddress !== undefined && relayAddress != null) {
-        relayAddress = address;
-    }
-}
-exports.setRelayAddress = setRelayAddress;
 
 /**
  * Remove a replication request from the queue based on the source and destination
@@ -285,7 +209,7 @@ function processTdhToTdhReplicationRequestPromise(requestKey) {
         promise = getEmptyPromise();
     } else {
         promise = new Promise(function (resolve, reject) {
-            var url = relayAddress + "/_replicate";
+            var url = TDHReplication.relayAddress + "/_replicate";
             var body = {
                 'source': request.from,
                 'target': request.to,

--- a/web/src/js/pouchdb_sync_library_test.js
+++ b/web/src/js/pouchdb_sync_library_test.js
@@ -14,7 +14,7 @@
 "use strict";
 
 // TDH and db information
-var localCouchInstance = "http://localhost:58000";
+var localCouchInstance = TDHReplication.relayAddress;
 var testDb1Name = "testdbone";
 var testDb2Name = "testdbtwo";
 
@@ -116,7 +116,7 @@ function get(url) {
 $(function() {
     var docBag = generateDocs(100);
 
-    var getHttpKeyUrl = "http://localhost:58000/_relayutility/localhttpkeys";
+    var getHttpKeyUrl = TDHReplication.relayAddress+"/_relayutility/localhttpkeys";
     var httpKeyUrl;
     get(getHttpKeyUrl).then(function(response) {
         var data = JSON.parse(response);

--- a/web/src/js/pouchdb_test.js
+++ b/web/src/js/pouchdb_test.js
@@ -14,7 +14,7 @@
 "use strict";
 
 // TDH and db information
-var localCouchInstance = "http://localhost:58000";
+var localCouchInstance = TDHReplication.relayAddress;
 var testDb1Name = "testdbone";
 var testDb2Name = "testdbtwo";
 

--- a/web/src/js/tdh_replication.js
+++ b/web/src/js/tdh_replication.js
@@ -21,7 +21,9 @@ exports = exports.TDHReplication;
 var enableDebugLogging = true;
 
 // what is the relay address?
+// This goes away with https://github.com/thaliproject/ThaliHTML5ApplicationFramework/issues/4
 var relayAddress = "http://localhost:58000";
+exports.relayAddress = relayAddress;
 
 function processTdhReplicationRequestPromise(source, target, isCancel) {
     if(isCancel === undefined) {
@@ -29,7 +31,7 @@ function processTdhReplicationRequestPromise(source, target, isCancel) {
     }
 
     var promise = new Promise(function (resolve, reject) {
-        var url = relayAddress + "/_replicate";
+        var url = exports.relayAddress + "/_replicate";
         var body = {
             'source': source,
             'target': target,
@@ -67,6 +69,5 @@ function removeTdhReplicationRequest(from, to) {
     return processTdhReplicationRequestPromise(from, to, true);
 }
 exports.removeTdhReplicationRequest = removeTdhReplicationRequest;
-
 
 })(typeof exports === 'undefined' ? this : exports);

--- a/web/src/js/tdh_replication_test.js
+++ b/web/src/js/tdh_replication_test.js
@@ -11,10 +11,12 @@
  See the Apache 2 License for the specific language governing permissions and limitations under the License.
  */
 
+(function(exports){
+
 "use strict";
 
 // TDH and db information
-var localCouchInstance = "http://localhost:58000";
+var localCouchInstance = TDHReplication.relayAddress;
 var testDb1Name = "testdbone";
 var testDb2Name = "testdbtwo";
 var testDb3Name = "testdbthree";
@@ -256,7 +258,7 @@ function get(url) {
 var state = "none";
 $(function() {
     $("#start_test").click(function() {
-        var getHttpKeyUrl = "http://localhost:58000/_relayutility/localhttpkeys";
+        var getHttpKeyUrl = TDHReplication.relayAddress + "/_relayutility/localhttpkeys";
         state = "get http key";
         get(getHttpKeyUrl).then(function (response) {
             var data = JSON.parse(response);
@@ -304,3 +306,5 @@ $(function() {
         });
     });
 });
+
+})(typeof exports === 'undefined' ? this : exports);


### PR DESCRIPTION
Added support for finding the socks proxy address
Added support for directly specifying relay port
Centralized where we declare relay port in JS to one place so we can change
 it later when we support dynamic relay ports.
